### PR TITLE
By default status codes are not checked and are passed back to the ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ RestEssentials is an extremely lightweight REST and JSON library for Swift.
 
 ## Features
 
-- [x] Easily perform asynchronous REST networking calls (GET, POST, PUT, or DELETE) that works with JSON
+- [x] Easily perform asynchronous REST networking calls (GET, POST, PUT, PATCH, or DELETE) that works with JSON
 - [x] Full JSON parsing capabilities
 - [x] HTTP response validation
 - [x] Send custom HTTP headers
@@ -93,7 +93,7 @@ guard let rest = RestController.createFromURLString("http://httpbin.org/get") el
     return
 }
 
-rest.get { result in
+rest.get { result, httpResponse in
     do {
         let json = try result.value()
         print(json)
@@ -115,7 +115,7 @@ guard let rest = RestController.createFromURLString("http://httpbin.org/post") e
 }
 
 def postData = JSON(dict: ["key1": "value1", "key2": 2, "key3": 4.5, "key4": true])
-try rest.post(withJSON: postData) { result in
+try rest.post(withJSON: postData) { result, httpResponse in
     do {
         let json = try result.value()
         print(json)

--- a/Tests/RestControllerTests.swift
+++ b/Tests/RestControllerTests.swift
@@ -29,7 +29,7 @@ class RestControllerTests: XCTestCase {
             return
         }
 
-        rest.get { result in
+        rest.get { result, httpResponse in
             do {
                 let json = try result.value()
                 print(json)
@@ -56,7 +56,7 @@ class RestControllerTests: XCTestCase {
             return
         }
 
-        try! rest.post("post", withJSON: JSON(dict: ["key1": "value1", "key2": 2, "key3": 4.5, "key4": true])) { result in
+        try! rest.post("post", withJSON: JSON(dict: ["key1": "value1", "key2": 2, "key3": 4.5, "key4": true])) { result, httpResponse in
             do {
                 let json = try result.value()
                 print(json)


### PR DESCRIPTION
…ller to handle

@ThomsonIT can you please take a look at this and let me know your thoughts? By default, the status codes are not checked (you can force it to check by adding an expectedStatusCode in the options).  The httpResponse (which contains the status code) is returned back to the caller.
